### PR TITLE
Fix bare soil evap coefs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,4 +29,4 @@ Encoding: UTF-8
 LazyData: true
 Config/testthat/edition: 3
 Language: en-US
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rSW2data
 Title: Input Data Preparation for SOILWAT2 and STEPWAT2 Simulation Experiments
-Version: 0.1.2-9000
+Version: 0.1.2
 Authors@R: c(
   person(
     "Daniel", "Schlaepfer",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rSW2data
 Title: Input Data Preparation for SOILWAT2 and STEPWAT2 Simulation Experiments
-Version: 0.1.1
+Version: 0.1.2-9000
 Authors@R: c(
   person(
     "Daniel", "Schlaepfer",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,11 @@
+# rSW2data v0.1.2-9000
+* `calc_calc_BareSoilEvapCoefs()` can now work with soils with
+  different soil depth profiles; correctly works in edge cases including
+  one soil layer or one site; improved passing bad sites through; and
+  consider soil texture of layers within `depth_max_bs_evap_cm`.
+
+# rSW2data v0.1.1
+* `impute_soils()` imputes now independently of order of sites and soil layers.
+
+# rSW2data v0.1.0
+* Initial release.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rSW2data v0.1.2-9000
+# rSW2data v0.1.2
 * `calc_calc_BareSoilEvapCoefs()` can now work with soils with
   different soil depth profiles; correctly works in edge cases including
   one soil layer or one site; improved passing bad sites through; and

--- a/man/rSW2data.Rd
+++ b/man/rSW2data.Rd
@@ -6,8 +6,7 @@
 \alias{rSW2data-package}
 \title{Package \pkg{rSW2data}: summary information}
 \description{
-Collection of functions to prepare and calculate input data for
-  rSOILWAT2, rSFSW2, and rSFSTEP2 simulation experiments.
+Collection of functions to prepare and calculate input data for rSOILWAT2, rSFSW2, and rSFSTEP2 simulation experiments.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
Improve `calc_calc_BareSoilEvapCoefs()`

- correct handling of sites with different soil depth profiles --> loop over groups of sites with identical depth profiles
- correct handling of 1 soil layer, 1 site, and passing bad sites through
- only consider soil texture in soil layers within `depth_max_bs_evap_cm`
- consistent output format